### PR TITLE
Add require for Net::HTTP as some rubies can't resolve it properly

### DIFF
--- a/lib/pinch_hitter.rb
+++ b/lib/pinch_hitter.rb
@@ -2,6 +2,7 @@ require "pinch_hitter/version"
 require "pinch_hitter/message/message_store"
 require "pinch_hitter/message/content_type"
 require "pinch_hitter/service/runner"
+require "net/http"
 
 module PinchHitter
   include PinchHitter::Service::Runner


### PR DESCRIPTION
Noticed this problem when trying to use the library on some Windows versions of Ruby.
