### PR TITLE
Add HTML content type

### DIFF
--- a/features/messages/document.txt
+++ b/features/messages/document.txt
@@ -1,0 +1,2 @@
+This is a plain text file.
+Nothing fancy here!

--- a/features/messages/page.html
+++ b/features/messages/page.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head></head>
+  <body>
+    <h1>I am a web page</h1>
+    <p>Look at me go!</p>
+  </body>
+</html>

--- a/features/replay.feature
+++ b/features/replay.feature
@@ -26,6 +26,11 @@ Feature:  Test WS replay
     When I query the glossary
     Then I see a definition with a "ID" of "FOO"
 
+  Scenario:  Replay with HTML
+    Given I want to view a web page
+    When I visit the web address
+    Then I see the web page
+
   Scenario:  Replay with plain text
     Given I want to retrieve a text document
     When I retrieve the text document

--- a/features/replay.feature
+++ b/features/replay.feature
@@ -26,6 +26,11 @@ Feature:  Test WS replay
     When I query the glossary
     Then I see a definition with a "ID" of "FOO"
 
+  Scenario:  Replay with plain text
+    Given I want to retrieve a text document
+    When I retrieve the text document
+    Then I see the text document
+
   Scenario Outline:  Replay with custom module
     Given I want to do some fancy processing
     When I query my service with <request>

--- a/features/step_definitions/replay_steps.rb
+++ b/features/step_definitions/replay_steps.rb
@@ -44,6 +44,19 @@ Then /^I see a definition with a "(.*?)" of "(.*?)"$/ do |key, value|
   @response.body.to_s.should == messages.load(:glossary, { key => value }).squish
 end
 
+Given /^I want to view a web page$/ do
+  mock.prime "/page", :page
+end
+
+When /^I visit the web address$/ do
+  @response = app.get "/page"
+end
+
+Then /^I see the web page$/ do
+  @response.body.to_s.should == messages.load(:page).squish
+  @response.header["Content-Type"].should == "text/html;charset=utf-8"
+end
+
 Given /^I want to retrieve a text document$/ do
   mock.prime "/document", :document
 end

--- a/features/step_definitions/replay_steps.rb
+++ b/features/step_definitions/replay_steps.rb
@@ -12,6 +12,7 @@ end
 
 Then /^I see a car reservation$/ do
   @response.body.to_s.should == messages.load(:car_rental).squish
+  @response.header["Content-Type"].should == "text/xml;charset=utf-8"
 end
 
 Given /^I want a car rental with a "(.*?)" of "(.*?)"$/ do |tag, text|
@@ -32,6 +33,7 @@ end
 
 Then /^I see a definition$/ do
   @response.body.to_s.should == messages.load(:glossary).squish
+  @response.header["Content-Type"].should == "application/json"
 end
 
 Given /^I want to lookup a definition with a "(.*?)" of "(.*?)"$/ do |key, value|
@@ -41,6 +43,20 @@ end
 Then /^I see a definition with a "(.*?)" of "(.*?)"$/ do |key, value|
   @response.body.to_s.should == messages.load(:glossary, { key => value }).squish
 end
+
+Given /^I want to retrieve a text document$/ do
+  mock.prime "/document", :document
+end
+
+When /^I retrieve the text document$/ do
+  @response = app.get "/document"
+end
+
+Then /^I see the text document$/ do
+  @response.body.to_s.should == messages.load(:document).squish
+  @response.header["Content-Type"].should == "text/plain;charset=utf-8"
+end
+
 
 Given(/^I want to do some fancy processing$/) do
   mock.register_module('/service', XmlParser)

--- a/lib/pinch_hitter.rb
+++ b/lib/pinch_hitter.rb
@@ -6,7 +6,6 @@ require "net/http"
 
 module PinchHitter
   include PinchHitter::Service::Runner
-  include PinchHitter::Message::ContentType
   attr_accessor :message_store
 
   def messages_directory=(dir)
@@ -30,7 +29,7 @@ module PinchHitter
   end
 
   def store(endpoint, content)
-    content_type = determine_content_type(content)
+    content_type = Message::ContentType.determine_content_type_by_message(content)
     @session.post "/store?endpoint=#{endpoint}", content, 'Content-Type' => content_type
   end
 

--- a/lib/pinch_hitter/message/content_type.rb
+++ b/lib/pinch_hitter/message/content_type.rb
@@ -44,5 +44,6 @@ module PinchHitter::Message
 end
 
 require 'pinch_hitter/message/json'
+require 'pinch_hitter/message/html'
 require 'pinch_hitter/message/xml'
 require 'pinch_hitter/message/plain_text'

--- a/lib/pinch_hitter/message/content_type.rb
+++ b/lib/pinch_hitter/message/content_type.rb
@@ -1,12 +1,48 @@
-require 'pinch_hitter/message/json'
+require 'set'
 
 module PinchHitter::Message
-  module ContentType
-    include Json
+  class ContentType
 
-    def determine_content_type(message)
-      return "application/json" if valid_json? message
-      "text/xml"
+    def self.determine_content_type_by_message(message)
+      content_type = registered_content_types.find do |type|
+        type.valid_message? message
+      end
+      content_type.header_string
     end
+
+    def self.determine_content_type_by_extension(extension)
+      registered_content_types.find do |type|
+        type.extension == extension
+      end
+    end
+
+    def self.registered_content_types
+      @registered_content_types ||= Set.new
+    end
+
+    def self.inherited(subclass)
+      registered_content_types << subclass
+    end
+
+    def self.valid_message?(message)
+      raise NotImplementedError
+    end
+
+    def self.format_message(message, overrides={})
+      raise NotImplementedError
+    end
+
+    def self.header_string
+      raise NotImplementedError
+    end
+
+    def self.extension
+      name[/(?<=::)[^:]+$/].downcase
+    end
+
   end
 end
+
+require 'pinch_hitter/message/json'
+require 'pinch_hitter/message/xml'
+require 'pinch_hitter/message/plain_text'

--- a/lib/pinch_hitter/message/html.rb
+++ b/lib/pinch_hitter/message/html.rb
@@ -2,7 +2,7 @@ module PinchHitter::Message
   class Html < ContentType
 
     def self.valid_message?(string)
-      string.start_with?(/(\s|<!doctype[^>]*>)*<html\b/i)
+      string =~ /\A(\s|<!doctype[^>]*>)*<html\b/i
     end
 
     def self.format_message(message, overrides={})

--- a/lib/pinch_hitter/message/html.rb
+++ b/lib/pinch_hitter/message/html.rb
@@ -1,0 +1,18 @@
+module PinchHitter::Message
+  class Html < ContentType
+
+    def self.valid_message?(string)
+      string.start_with?(/(\s|<!doctype[^>]*>)*<html\b/i)
+    end
+
+    def self.format_message(message, overrides={})
+      raise "Overrides are not supported for HTML responses" unless overrides.empty?
+      message
+    end
+
+    def self.header_string
+      "text/html"
+    end
+
+  end
+end

--- a/lib/pinch_hitter/message/json.rb
+++ b/lib/pinch_hitter/message/json.rb
@@ -1,27 +1,9 @@
 module PinchHitter::Message
-  module Json
-    def json_message(file, overrides={})
-      json_file = load_json_file file
-      replace_json json_file, overrides
-    end
+  class Json < ContentType
 
-    def valid_json?(json)
-      begin
-        JSON.parse json
-        return true
-      rescue
-        return false
-      end
-    end
-
-  private
-    def load_json_file(filename)
-      IO.read filename
-    end
-
-    def replace_json(content, overrides={})
-      return content if overrides.empty?
-      doc = JSON.parse(content)
+    def self.format_message(message, overrides={})
+      return message if overrides.empty?
+      doc = JSON.parse(message)
       overrides.each do |key, value|
         hash = find_nested_hash(doc, key)
         if has_key(hash, key)
@@ -31,7 +13,19 @@ module PinchHitter::Message
       doc.to_json
     end
 
-    def find_nested_hash(parent, key)
+    def self.valid_message?(string)
+      JSON.parse string
+      return true
+    rescue
+      return false
+    end
+
+    def self.header_string
+      "application/json"
+    end
+
+    private
+    def self.find_nested_hash(parent, key)
       return parent if has_key(parent, key)
       return nil unless parent.respond_to? :each
 
@@ -42,7 +36,7 @@ module PinchHitter::Message
       found
     end
 
-    def has_key(hash, key)
+    def self.has_key(hash, key)
       hash.respond_to?(:key?) && hash.key?(key)
     end
 

--- a/lib/pinch_hitter/message/message_store.rb
+++ b/lib/pinch_hitter/message/message_store.rb
@@ -1,12 +1,7 @@
-require 'pinch_hitter/message/xml'
-require 'pinch_hitter/message/json'
 require 'pinch_hitter/message/content_type'
 
 module PinchHitter::Message
-    class MessageStore
-    include Xml
-    include Json
-    include ContentType
+  class MessageStore
 
     attr_accessor :message_directory
 
@@ -16,11 +11,11 @@ module PinchHitter::Message
 
     def load(file, overrides={})
       filename = find_filename file
-      if filename =~ /xml$/
-        xml_message filename, overrides
-      else
-        json_message filename, overrides
-      end
+      file_extension = filename[/(?<=\.)[^.]+$/]
+      fail "Filename must have an extension to indicate type of response (#{filename})" if file_extension.nil?
+      content_type = ContentType.determine_content_type_by_extension file_extension
+      fail "Unsupported file type #{file_extension.inspect}. Supported types are: #{ContentType.registered_content_types.map(&:extension)}" if content_type.nil?
+      content_type.format_message File.read(filename), overrides
     end
 
     def find_filename(file)

--- a/lib/pinch_hitter/message/plain_text.rb
+++ b/lib/pinch_hitter/message/plain_text.rb
@@ -1,0 +1,22 @@
+module PinchHitter::Message
+  class PlainText < ContentType
+
+    def self.valid_message?(message)
+      true
+    end
+
+    def self.format_message(message, overrides={})
+      raise "Overrides are not supported for Plain Text responses" unless overrides.empty?
+      message
+    end
+
+    def self.header_string
+      "text/plain"
+    end
+
+    def self.extension
+      "txt"
+    end
+
+  end
+end

--- a/lib/pinch_hitter/message/xml.rb
+++ b/lib/pinch_hitter/message/xml.rb
@@ -2,22 +2,26 @@ require 'rexml/document'
 require 'rexml/xpath'
 
 module PinchHitter::Message
-  module Xml
-    def xml_message(file, overrides={})
-      xml = load_xml_file(file)
+  class Xml < ContentType
+
+    def self.valid_message?(string)
+      string.start_with?(/\s*<(\?xml|soap)/i)
+    end
+
+    def self.format_message(message, overrides={})
+      xml = REXML::Document.new message
       overrides.each do |key, text|
         replace_xml(xml, key, text)
       end
       xml.to_s
     end
 
-    private
-    def load_xml_file(filename)
-      file = File.new filename
-      REXML::Document.new file
+    def self.header_string
+      "text/xml"
     end
 
-    def replace_xml(xml, key, text)
+    private
+    def self.replace_xml(xml, key, text)
       parts = key.split('@')
       tag = find_node xml, parts.first
 
@@ -30,7 +34,7 @@ module PinchHitter::Message
       end
     end
 
-    def find_node(xml, tag)
+    def self.find_node(xml, tag)
       REXML::XPath.first(xml, "//#{tag}")
     end
   end

--- a/lib/pinch_hitter/message/xml.rb
+++ b/lib/pinch_hitter/message/xml.rb
@@ -5,7 +5,7 @@ module PinchHitter::Message
   class Xml < ContentType
 
     def self.valid_message?(string)
-      string.start_with?(/\s*<(\?xml|soap)/i)
+      string =~ /\A\s*<(\?xml|soap)/i
     end
 
     def self.format_message(message, overrides={})

--- a/lib/pinch_hitter/service/replay_ws.rb
+++ b/lib/pinch_hitter/service/replay_ws.rb
@@ -9,7 +9,6 @@ require 'pinch_hitter/message/content_type'
 
 module PinchHitter::Service
   class ReplayWs < Sinatra::Base
-    include PinchHitter::Message::ContentType
 
     register Sinatra::CrossOrigin
 
@@ -88,7 +87,7 @@ module PinchHitter::Service
       @@recorder.record(endpoint, request)
       message = @@handlers.respond_to(endpoint, body, request, response)
       if message.is_a? String
-        content_type determine_content_type message
+        content_type PinchHitter::Message::ContentType.determine_content_type_by_message message
         puts "No message found for #{endpoint}" unless message
       end
       message

--- a/test/message_assertions.rb
+++ b/test/message_assertions.rb
@@ -15,6 +15,17 @@ module MessageAssertions
     }}~
   end
 
+  def html_message
+   %Q{<!doctype html>
+<html>
+  <body>Hi hi!</body>
+</html>}
+  end
+
+  def text_message
+   %Q{Howdie doodie neighbor?}
+  end
+
   def assert_received(message)
     assert_equal message.gsub(/\n\s*/, ''), last_response.body.strip
   end

--- a/test/test_html_message.rb
+++ b/test/test_html_message.rb
@@ -1,0 +1,33 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'minitest/autorun'
+
+class TestHtmlMessage < MiniTest::Test
+
+  def html_message
+%Q{<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <h1>Hello there</h1>
+    <p>How are you?</p>
+  </body>
+</html>}
+  end
+
+  def test_message_no_overrides
+    assert_equal html_message, PinchHitter::Message::Html.format_message(html_message)
+  end
+
+  def test_message_with_empty_overrides_is_fine
+    assert_equal html_message, PinchHitter::Message::Html.format_message(html_message, {})
+  end
+
+  def test_message_with_overrides_raises_an_error
+    error = assert_raises RuntimeError do
+      PinchHitter::Message::Html.format_message(html_message, { "h1" => 'WhatsUpDoc?' })
+    end
+
+    assert_equal error.message, "Overrides are not supported for HTML responses"
+  end
+end

--- a/test/test_json_message.rb
+++ b/test/test_json_message.rb
@@ -4,21 +4,7 @@ require 'minitest/autorun'
 
 class TestJsonMessage < MiniTest::Test
 
-  def setup
-   File.open(filename, 'w') {|f| f.write(our_message) }
-   @test = Object.new
-   @test.extend(PinchHitter::Message::Json)
-  end
-
-  def teardown
-    File.delete filename
-  end
-
-  def filename
-    "minitest_message.json"
-  end
-
-  def our_message
+  def json_message
 %Q{{"menu": {
   "id": "file",
   "value": "File",
@@ -32,12 +18,12 @@ class TestJsonMessage < MiniTest::Test
 }
   end
 
-  def test_message_no_overrides 
-    assert_equal our_message, @test.json_message(filename)
+  def test_message_no_overrides
+    assert_equal json_message, PinchHitter::Message::Json.format_message(json_message)
   end
 
   def test_message_with_overrides
-    json = @test.json_message(filename, {"menuitem" => 'WhatsUpDoc?' })
+    json = PinchHitter::Message::Json.format_message(json_message, { "menuitem" => 'WhatsUpDoc?' })
     assert json.include? "WhatsUpDoc?"
   end
 end

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -7,6 +7,7 @@ class TestMessage < MiniTest::Test
   def setup
    File.open(xml_file,  'w') { |f| f.write(xml_message) }
    File.open(json_file, 'w') { |f| f.write(json_message) }
+   File.open(html_file, 'w') { |f| f.write(html_message) }
 
    @messages = PinchHitter::Message::MessageStore.new File.dirname('.')
   end
@@ -14,6 +15,7 @@ class TestMessage < MiniTest::Test
   def teardown
     File.delete xml_file
     File.delete json_file
+    File.delete html_file
   end
 
   def xml_file
@@ -22,6 +24,10 @@ class TestMessage < MiniTest::Test
 
   def json_file
     "minitest.json"
+  end
+
+  def html_file
+    "minitest.html"
   end
 
   def xml_message
@@ -34,6 +40,15 @@ class TestMessage < MiniTest::Test
 %Q{{
   "one": "two",
   "A": "B" }
+}
+  end
+
+  def html_message
+%Q{<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>Hi there!</body>
+</html>
 }
   end
 
@@ -61,6 +76,10 @@ class TestMessage < MiniTest::Test
 
   def test_content_type_determines_json
     assert_equal "application/json", PinchHitter::Message::ContentType.determine_content_type_by_message(json_message)
+  end
+
+  def test_content_type_determines_html
+    assert_equal "text/html", PinchHitter::Message::ContentType.determine_content_type_by_message(html_message)
   end
 
   def test_content_type_defaults_to_plain_text

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -5,24 +5,23 @@ require 'minitest/autorun'
 class TestMessage < MiniTest::Test
 
   def setup
-   File.open("#{xml_filename}.xml", 'w') {|f| f.write(xml_message) }
-
-   File.open("#{json_file}", 'w') { |f| f.write(json_message) }
+   File.open(xml_file,  'w') { |f| f.write(xml_message) }
+   File.open(json_file, 'w') { |f| f.write(json_message) }
 
    @messages = PinchHitter::Message::MessageStore.new File.dirname('.')
   end
 
   def teardown
-    File.delete "#{xml_filename}.xml"
-    File.delete "#{json_file}"
+    File.delete xml_file
+    File.delete json_file
   end
 
-  def xml_filename
-    "minitest_xml"
+  def xml_file
+    "minitest.xml"
   end
 
   def json_file
-    "minitest_json"
+    "minitest.json"
   end
 
   def xml_message
@@ -44,7 +43,7 @@ class TestMessage < MiniTest::Test
   end
 
   def test_loads_xml
-    assert_equal xml_message, @messages.load(xml_filename.to_sym)
+    assert_equal xml_message, @messages.load(xml_file.to_sym)
   end
 
   def test_loads_json
@@ -53,14 +52,18 @@ class TestMessage < MiniTest::Test
 
   def test_message_no_whitespace
     squish = %Q{<?xml version='1.0' encoding='UTF-8'?><Body/>}
-    assert_equal squish, @messages.load(xml_filename.to_sym).squish
+    assert_equal squish, @messages.load(xml_file.to_sym).squish
   end
 
-  def test_content_type_defaults_to_xml
-    assert_equal "text/xml", @messages.determine_content_type("")
+  def test_content_type_determines_xml
+    assert_equal "text/xml", PinchHitter::Message::ContentType.determine_content_type_by_message(xml_message)
   end
 
   def test_content_type_determines_json
-    assert_equal "application/json", @messages.determine_content_type(json_message)
+    assert_equal "application/json", PinchHitter::Message::ContentType.determine_content_type_by_message(json_message)
+  end
+
+  def test_content_type_defaults_to_plain_text
+    assert_equal "text/plain", PinchHitter::Message::ContentType.determine_content_type_by_message("")
   end
 end

--- a/test/test_pinch_hitter.rb
+++ b/test/test_pinch_hitter.rb
@@ -13,7 +13,7 @@ class TestPinchHitter < MiniTest::Test
    @test.session=session
    @test.reset
    @test.messages_directory = File.dirname('.')
-   File.open(message_file, 'w') {|f| f.write(message_content) }
+   File.open(message_file, 'w') { |f| f.write(message_content) }
   end
 
   def teardown
@@ -21,7 +21,7 @@ class TestPinchHitter < MiniTest::Test
   end
 
   def message_file
-    "fizzbuzz"
+    "fizzbuzz.txt"
   end
 
   def message_content
@@ -53,12 +53,10 @@ class TestPinchHitter < MiniTest::Test
   end
 
   def test_prime_with_missing_message
-    begin
-      @test.prime '/foo', :non_existent_file
-    rescue => e
-      assert_match "Could not find message", e.message
-      assert_match :non_existent_file.to_s, e.message
-    end
+    @test.prime '/foo', :non_existent_file
+  rescue => e
+    assert_match "Could not find message", e.message
+    assert_match :non_existent_file.to_s, e.message
   end
 
   def test_store

--- a/test/test_plain_text_message.rb
+++ b/test/test_plain_text_message.rb
@@ -1,0 +1,27 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'minitest/autorun'
+
+class TestPlainTextMessage < MiniTest::Test
+
+  def text_message
+%Q{This is a plain text document.
+It has two lines.}
+  end
+
+  def test_message_no_overrides
+    assert_equal text_message, PinchHitter::Message::PlainText.format_message(text_message)
+  end
+
+  def test_message_with_empty_overrides_is_fine
+    assert_equal text_message, PinchHitter::Message::PlainText.format_message(text_message, {})
+  end
+
+  def test_message_with_overrides_raises_an_error
+    error = assert_raises RuntimeError do
+      PinchHitter::Message::PlainText.format_message(text_message, { "item" => 'WhatsUpDoc?' })
+    end
+
+    assert_equal error.message, "Overrides are not supported for Plain Text responses"
+  end
+end

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -33,6 +33,13 @@ class TestService < MiniTest::Test
     assert_equal 'application/json', last_response.content_type
   end
 
+  def test_result_should_be_plain_text
+    post "/store", text_message
+    post "/respond", ''
+
+    assert_equal 'text/plain;charset=utf-8', last_response.content_type
+  end
+
   def test_reset
     post "/reset", ''
     assert_equal 200, last_response.status

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -40,6 +40,13 @@ class TestService < MiniTest::Test
     assert_equal 'text/plain;charset=utf-8', last_response.content_type
   end
 
+  def test_result_should_be_html
+    post "/store", html_message
+    post "/respond", ''
+
+    assert_equal 'text/html;charset=utf-8', last_response.content_type
+  end
+
   def test_reset
     post "/reset", ''
     assert_equal 200, last_response.status

--- a/test/test_xml_message.rb
+++ b/test/test_xml_message.rb
@@ -4,21 +4,7 @@ require 'minitest/autorun'
 
 class TestXmlMessage < MiniTest::Test
 
-  def setup
-   File.open(filename, 'w') {|f| f.write(our_message) }
-   @test = Object.new
-   @test.extend(PinchHitter::Message::Xml)
-  end
-
-  def teardown
-    File.delete filename
-  end
-
-  def filename
-    "minitest_message.xml"
-  end
-
-  def our_message
+  def xml_message
 %Q{<?xml version='1.0' encoding='UTF-8'?>
 <wrapper>
   <Body xmlns:ns='http://www.abc.org/OTA/2003/05'>
@@ -31,22 +17,22 @@ class TestXmlMessage < MiniTest::Test
   end
 
   def test_message_no_overrides
-    assert_equal our_message, @test.xml_message(filename)
+    assert_equal xml_message, PinchHitter::Message::Xml.format_message(xml_message)
   end
 
   def test_message_tag_override
-    xml = @test.xml_message(filename, {"node" => "newtext"})
+    xml = PinchHitter::Message::Xml.format_message(xml_message, {"node" => "newtext"})
     assert xml.include? "<node>newtext</node>"
   end
 
   def test_message_tag_override_attrib
-    xml = @test.xml_message(filename,
+    xml = PinchHitter::Message::Xml.format_message(xml_message,
         {"withattrib@attrib" => "BetterValue"})
     assert xml.include? "<withattrib attrib='BetterValue'"
   end
 
   def test_message_tag_override_with_namespace
-    xml = @test.xml_message(filename, {"ns:testnode" => 'newValue'})
+    xml = PinchHitter::Message::Xml.format_message(xml_message, {"ns:testnode" => 'newValue'})
     assert xml.include? "<ns:testnode>newValue</ns:testnode>"
   end
 end


### PR DESCRIPTION
As I mentioned, we need the server to respond with the proper content type header for HTML responses. This feature does that. We refactored a bit to make this easier (the first commit), and in that process made some possibly objectionable changes to some interfaces. They're detailed in the commit message, so I'll refer you to that for more details.

Let me know if you want me to rework any of the refactoring bit -- I'm sure I can do a better job of preserving the original interfaces more if you think I'd be creating problems!