### PR TITLE
Disable security protections on replay web server

### DIFF
--- a/lib/pinch_hitter/service/replay_ws.rb
+++ b/lib/pinch_hitter/service/replay_ws.rb
@@ -21,6 +21,7 @@ module PinchHitter::Service
       mime_type :xml, "text/xml"
       mime_type :json, "application/json"
       disable :no_cache
+      disable :protection
     end
 
 

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -148,6 +148,13 @@ class TestService < MiniTest::Test
     app.disable :no_cache
   end
 
+  def test_cors_protections_are_off
+    post "/store", xml_message
+    post "/respond", ''
+
+    assert_equal last_response["X-Frame-Options"], nil
+  end
+
   def test_request_handler
     post '/register_module?endpoint=stuff', Marshal.dump(TestRequestHandler)
     post '/stuff', ''


### PR DESCRIPTION
Fixes #15 

This is kind of a sledge hammer solution to something that could be solved with a scalpel. I'm completely disabling the built-in protections Sinatra ships with. However, in our use case I think this is fine, since this is intended for testing use cases.

If you'd prefer, I can specifically exclude the X-Frame-Options header just by itself, but this seemed reasonable to me. Correct me if I'm wrong!